### PR TITLE
feat: MLX VRAM & performance optimizations for Apple Silicon

### DIFF
--- a/docs/benchmarks/baseline-fp32.md
+++ b/docs/benchmarks/baseline-fp32.md
@@ -1,0 +1,31 @@
+# Baseline Benchmarks (FP32, no optimizations)
+
+Date: 2026-03-07
+Hardware: Apple M4 Max (128GB unified)
+MLX version: 0.24.2
+Weights: corridorkey_mlx.safetensors (real checkpoint)
+Config: warmup=2, bench=3, batch=1, eager+compiled (isolated per resolution)
+NOTE: Captured under load — latency numbers not representative. Re-run on idle system. Memory numbers should be stable.
+
+## Results
+
+| Resolution | Eager Steady (ms) | Compiled Steady (ms) | Speedup | Peak MB  | Active MB |
+|------------|-------------------:|---------------------:|--------:|---------:|----------:|
+| 512x512    |              219.7 |                173.8 |   1.26x |   2554.4 |     555.1 |
+| 1024x1024  |              865.0 |                793.7 |   1.09x |   3673.1 |     609.1 |
+| 2048x2048  |            10434.0 |               7076.7 |   1.47x |  26689.0 |     825.1 |
+
+## Key Observations
+
+- Peak memory at 2048: ~26.7 GB — well above the <6 GB target
+- Active memory stays modest (~825 MB at 2048) — peak dominated by intermediate computation graphs
+- Compiled speedup: 1.1-1.5x across resolutions
+- 26.7 GB peak at 2048 suggests massive intermediate tensor allocation during Hiera backbone
+- Active memory (what's alive after forward pass) is only ~825 MB — most peak usage is transient
+
+## Targets (from plan)
+
+| Metric | Current | Target |
+|--------|--------:|-------:|
+| Peak memory at 2048 (non-tiled) | 26689 MB | <6000 MB |
+| Throughput at 2048 (compiled) | 7077 ms | ~3500-4700 ms (1.5-2x) |

--- a/docs/plans/2026-03-07-feat-mlx-vram-performance-optimizations-plan.md
+++ b/docs/plans/2026-03-07-feat-mlx-vram-performance-optimizations-plan.md
@@ -91,19 +91,20 @@ Halve memory footprint and boost M-series ALU throughput.
 
 #### Tasks
 
-- [ ] **1a. FP16 weight casting** -- src/corridorkey_mlx/inference/pipeline.py
+- [x] **1a. FP16 weight casting** -- src/corridorkey_mlx/inference/pipeline.py
   - After load_checkpoint(), cast via: model.update(tree_map(lambda x: x.astype(mx.float16), model.parameters()))
   - Cast BEFORE materializing parameters -- lazy graph means FP32 never materializes, saving ~200MB peak
   - Input tensor must also be cast: x = x.astype(mx.float16) before model(x)
-- [ ] **1b. FP16 parity test** -- tests/test_fp16_parity.py
+- [x] **1b. FP16 parity test** -- tests/test_fp16_parity.py
   - Compare FP16 MLX output vs FP32 MLX output (NOT vs PyTorch golden)
   - Tolerance: 1e-3 for final outputs (looser than FP32-vs-PT because FP16 drift + refiner's 10x scale)
   - Test all 4 engine-relevant outputs: alpha_coarse, fg_coarse, alpha_final, fg_final
-- [ ] **1c. Mixed precision fallback**
-  - If full FP16 exceeds tolerance (especially in Hiera's 24 blocks with cumulative drift, or refiner's REFINER_SCALE=10.0 amplifying rounding):
-  - Keep HieraBackbone in FP32, cast only DecoderHead and CNNRefinerModule to FP16
-  - Implementation: selective tree_map on model.alpha_decoder, model.fg_decoder, model.refiner
-- [ ] **1d. Add fp16: bool parameter** to load_model() in pipeline.py
+- [x] **1c. Mixed precision fallback**
+  - Full FP16 exceeded tolerance: backbone drift (2.5e-3 coarse) + refiner 10x scale (1.3e-2 final)
+  - Mixed precision v1 (backbone FP32, decoder+refiner FP16): refiner still exceeded (2.3e-3 final)
+  - Final: backbone + refiner FP32, decoders FP16 — all outputs within 1e-3
+  - Implementation: selective tree_map on model.alpha_decoder, model.fg_decoder only
+- [x] **1d. Add fp16: bool parameter** to load_model() in pipeline.py
 
 #### Key Risk
 
@@ -111,9 +112,9 @@ GroupNorm with pytorch_compatible=True in the refiner: variance computation at F
 
 #### Acceptance Criteria
 
-- [ ] FP16 parity test passes at 1e-3 tolerance
-- [ ] Peak memory at 512 drops ~40-50% vs FP32 baseline
-- [ ] Existing FP32 parity tests unaffected (FP16 is opt-in)
+- [x] FP16 parity test passes at 1e-3 tolerance
+- [ ] Peak memory at 512 drops ~40-50% vs FP32 baseline (decoders-only FP16 = ~20% expected)
+- [x] Existing FP32 parity tests unaffected (FP16 is opt-in)
 
 ---
 

--- a/docs/plans/2026-03-07-feat-mlx-vram-performance-optimizations-plan.md
+++ b/docs/plans/2026-03-07-feat-mlx-vram-performance-optimizations-plan.md
@@ -48,6 +48,12 @@ This means process_frame() branches based on whether tiling is active.
 
 ---
 
+## Branch
+
+Feature branch: `feat/misc-optimizations`
+
+---
+
 ## Implementation Phases
 
 ### Phase 0: Benchmarking Infrastructure & Baseline
@@ -56,26 +62,26 @@ Set up measurement tooling before altering anything.
 
 #### Tasks
 
-- [ ] **0a. Memory profiling helpers** -- src/corridorkey_mlx/utils/profiling.py
+- [x] **0a. Memory profiling helpers** -- src/corridorkey_mlx/utils/profiling.py
   - Add memory_snapshot() returning {active_mb, peak_mb, cache_mb}
   - Uses mx.get_active_memory(), mx.get_peak_memory(), mx.get_cache_memory()
   - Add reset_peak() wrapper around mx.reset_peak_memory()
-- [ ] **0b. Update scripts/bench_mlx.py**
+- [x] **0b. Update scripts/bench_mlx.py**
   - Add memory columns (peak MB, active MB) to the results table
   - Call mx.reset_peak_memory() before each bench run
   - Report mx.get_peak_memory() after graph materialization
-- [ ] **0c. Update scripts/smoke_2048.py**
+- [x] **0c. Update scripts/smoke_2048.py**
   - Replace the try/except fallback chain with the correct mx.* APIs
   - Add cache memory reporting
-- [ ] **0d. Capture baseline numbers** at 512, 1024, 2048
+- [x] **0d. Capture baseline numbers** at 512, 1024, 2048
   - Document: peak memory, active memory, median latency
   - This determines feasibility of the <6GB target
 
 #### Acceptance Criteria
 
-- [ ] scripts/bench_mlx.py prints memory columns for each resolution
-- [ ] Baseline numbers documented in a docs/benchmarks/ file
-- [ ] All existing tests pass (uv run pytest)
+- [x] scripts/bench_mlx.py prints memory columns for each resolution
+- [x] Baseline numbers documented in a docs/benchmarks/ file
+- [x] All existing tests pass (uv run pytest)
 
 ---
 

--- a/docs/plans/2026-03-07-feat-mlx-vram-performance-optimizations-plan.md
+++ b/docs/plans/2026-03-07-feat-mlx-vram-performance-optimizations-plan.md
@@ -1,0 +1,321 @@
+---
+title: "feat: MLX VRAM & Performance Optimizations for Apple Silicon Engine"
+type: feat
+date: 2026-03-07
+---
+
+# MLX VRAM & Performance Optimizations
+
+## Overview
+
+Six-phase optimization plan targeting memory reduction and throughput improvement in the corridorkey-mlx inference pipeline. Ports PyTorch branch breakthroughs (FP16, decoupled resolutions, 96px overlap) and adds Apple Silicon-specific memory management (lazy slicing, cache clearing, memory limits).
+
+## Problem Statement
+
+Current pain points at 2048x2048:
+
+1. **FP32 everywhere** -- model weights + activations fully float32, wasting memory bandwidth and ALU throughput on M-series chips
+2. **No memory management** -- no cache clearing between tiles, no memory limits, no cleanup of intermediates
+3. **CPU-GPU roundtrips** -- preprocessing does numpy to PIL to numpy to mx.array; postprocessing does the reverse
+4. **Backbone at full resolution** -- Hiera runs at 2048x2048 (saturates GPU cores) when 1024 suffices
+5. **9 output tensors** -- forward pass returns 9 tensors but engine only uses 4 (alpha_coarse/final, fg_coarse/final)
+6. **Tiling not integrated** -- tiled_inference() exists in inference/tiling.py but is unreachable from CorridorKeyMLXEngine
+
+## Technical Approach
+
+### API Corrections (from research)
+
+The original spec referenced incorrect API paths. Corrected:
+
+| Original (wrong) | Correct (MLX v0.31+) |
+|---|---|
+| mx.metal.get_peak_memory() | mx.get_peak_memory() |
+| mx.metal.get_active_memory() | mx.get_active_memory() |
+| mx.metal.clear_cache() | mx.clear_cache() |
+| n/a | mx.get_cache_memory() |
+| n/a | mx.reset_peak_memory() |
+| n/a | mx.set_cache_limit(limit) |
+| n/a | mx.set_memory_limit(limit) |
+
+### Architecture Decision: Two Pipeline Paths
+
+Phase 2 (all-MLX preprocessing) and Phase 4 (numpy outer loop for tiling) are contradictory. Resolution:
+
+- **Non-tiled path**: Phase 2 applies -- all preprocessing stays as mx.array, single np.array() at the end
+- **Tiled path**: Phase 4 applies -- full image stays as numpy, only tile slices become mx.array on demand
+
+This means process_frame() branches based on whether tiling is active.
+
+---
+
+## Implementation Phases
+
+### Phase 0: Benchmarking Infrastructure & Baseline
+
+Set up measurement tooling before altering anything.
+
+#### Tasks
+
+- [ ] **0a. Memory profiling helpers** -- src/corridorkey_mlx/utils/profiling.py
+  - Add memory_snapshot() returning {active_mb, peak_mb, cache_mb}
+  - Uses mx.get_active_memory(), mx.get_peak_memory(), mx.get_cache_memory()
+  - Add reset_peak() wrapper around mx.reset_peak_memory()
+- [ ] **0b. Update scripts/bench_mlx.py**
+  - Add memory columns (peak MB, active MB) to the results table
+  - Call mx.reset_peak_memory() before each bench run
+  - Report mx.get_peak_memory() after graph materialization
+- [ ] **0c. Update scripts/smoke_2048.py**
+  - Replace the try/except fallback chain with the correct mx.* APIs
+  - Add cache memory reporting
+- [ ] **0d. Capture baseline numbers** at 512, 1024, 2048
+  - Document: peak memory, active memory, median latency
+  - This determines feasibility of the <6GB target
+
+#### Acceptance Criteria
+
+- [ ] scripts/bench_mlx.py prints memory columns for each resolution
+- [ ] Baseline numbers documented in a docs/benchmarks/ file
+- [ ] All existing tests pass (uv run pytest)
+
+---
+
+### Phase 1: Selective FP16 Inference
+
+Halve memory footprint and boost M-series ALU throughput.
+
+#### Tasks
+
+- [ ] **1a. FP16 weight casting** -- src/corridorkey_mlx/inference/pipeline.py
+  - After load_checkpoint(), cast via: model.update(tree_map(lambda x: x.astype(mx.float16), model.parameters()))
+  - Cast BEFORE materializing parameters -- lazy graph means FP32 never materializes, saving ~200MB peak
+  - Input tensor must also be cast: x = x.astype(mx.float16) before model(x)
+- [ ] **1b. FP16 parity test** -- tests/test_fp16_parity.py
+  - Compare FP16 MLX output vs FP32 MLX output (NOT vs PyTorch golden)
+  - Tolerance: 1e-3 for final outputs (looser than FP32-vs-PT because FP16 drift + refiner's 10x scale)
+  - Test all 4 engine-relevant outputs: alpha_coarse, fg_coarse, alpha_final, fg_final
+- [ ] **1c. Mixed precision fallback**
+  - If full FP16 exceeds tolerance (especially in Hiera's 24 blocks with cumulative drift, or refiner's REFINER_SCALE=10.0 amplifying rounding):
+  - Keep HieraBackbone in FP32, cast only DecoderHead and CNNRefinerModule to FP16
+  - Implementation: selective tree_map on model.alpha_decoder, model.fg_decoder, model.refiner
+- [ ] **1d. Add fp16: bool parameter** to load_model() in pipeline.py
+
+#### Key Risk
+
+GroupNorm with pytorch_compatible=True in the refiner: variance computation at FP16 may amplify errors. The REFINER_SCALE=10.0 multiplier turns a 5e-5 rounding error into 5e-4. Validate refiner delta specifically.
+
+#### Acceptance Criteria
+
+- [ ] FP16 parity test passes at 1e-3 tolerance
+- [ ] Peak memory at 512 drops ~40-50% vs FP32 baseline
+- [ ] Existing FP32 parity tests unaffected (FP16 is opt-in)
+
+---
+
+### Phase 2: Eliminate CPU-GPU Roundtrips (Non-Tiled Path)
+
+Applies only to the non-tiled process_frame() path.
+
+#### Tasks
+
+- [ ] **2a. Audit engine.py:process_frame()** -- identify all numpy/PIL conversions
+  - Current flow: uint8 ndarray -> float32 ndarray -> PIL resize -> ndarray -> ImageNet norm -> mx.array
+  - Target flow: uint8 ndarray -> mx.array -> mx resize -> ImageNet norm (single conversion)
+- [ ] **2b. MLX-native resize**
+  - Replace PIL resize with nn.Upsample(scale_factor=..., mode="linear") or precomputed scale
+  - Note: nn.Upsample takes scale factors, not target sizes. Compute scale factor from input/target dims
+- [ ] **2c. MLX-native preprocessing**
+  - ImageNet normalization as mx.array ops: (x - mean) / std with broadcast constants
+  - Alpha hint concatenation as mx.concatenate
+- [ ] **2d. Final sync only**
+  - Move np.array(result) to the absolute end of process_frame()
+  - All postprocessing (sigmoid, clamp, scale to uint8) stays as mx.array ops
+- [ ] **2e. Slim forward mode** (opportunistic)
+  - Add slim=True parameter to GreenFormer.__call__() that skips returning the 5 unused intermediate tensors
+  - Only compute/return: alpha_coarse, fg_coarse, alpha_final, fg_final
+  - Saves ~25% intermediate VRAM at 2048
+
+#### Acceptance Criteria
+
+- [ ] process_frame() has exactly ONE np.array() call (at return)
+- [ ] No PIL imports in the hot path
+- [ ] Engine integration test passes with same output shapes/dtypes
+
+---
+
+### Phase 3: Decouple Backbone and Refiner Resolutions
+
+Biggest VRAM win -- backbone at 1024 instead of 2048.
+
+#### Tasks
+
+- [ ] **3a. Restructure GreenFormer.__call__()** -- src/corridorkey_mlx/model/corridorkey.py
+  - Add backbone_size: int | None = None parameter
+  - If backbone_size is set and differs from input spatial dims:
+    1. Store original full-res input x_full = x
+    2. Downsample x to (1, backbone_size, backbone_size, 4) using bilinear (nn.Upsample mode="linear")
+    3. Run backbone + decoder at backbone_size
+    4. Upsample decoder outputs (alpha_coarse, fg_coarse) back to full resolution
+    5. Extract RGB from x_full[:, :, :, :3] for refiner concatenation
+    6. Run refiner at full resolution
+  - If backbone_size is None or matches input, current behavior preserved
+- [ ] **3b. pos_embed alignment**
+  - Verify _interpolate_pos_embed works correctly for backbone_size=1024 (tokens_spatial_shape=[256,256]=65536)
+  - This is a 4x downsample from training res (2048). Already handled by cubic interpolation, but validate quality
+- [ ] **3c. Compilation strategy**
+  - With dual resolutions in one forward pass, mx.compile on the whole __call__ sees varying internal shapes
+  - Option A: Don't compile when backbone_size differs from input (simplest)
+  - Option B: Split into compiled_backbone(x_down) + compiled_refiner(x_full, coarse) (better perf)
+  - Recommend Option A first, Option B as follow-up
+- [ ] **3d. Quality validation**
+  - No PyTorch reference exists for this modified architecture
+  - Validate by visual inspection on real frames + comparing coarse outputs at 1024 vs 2048
+  - Document acceptable quality delta (this is a lossy optimization)
+- [ ] **3e. Parity test update**
+  - Add test_decoupled_resolution.py -- not a parity test vs golden, but a regression test:
+  - Assert outputs are valid (no NaN/Inf, alpha in [0,1], reasonable value ranges)
+  - Assert shapes match full-resolution output
+
+#### Key Risk: Tiling Interaction
+
+If tiling is active (Phase 4), tiles are 512x512. With backbone_size=1024, each tile is smaller than the backbone expects. Decision: **tiling ignores backbone_size** (tiles always run at tile_size). Simpler and avoids wasteful upsampling.
+
+#### Acceptance Criteria
+
+- [ ] GreenFormer(backbone_size=1024) produces valid outputs at 2048x2048 input
+- [ ] Peak memory at 2048 drops significantly vs Phase 1 baseline
+- [ ] backbone_size=None preserves exact existing behavior (backward compatible)
+- [ ] Compilation still works when backbone_size=None
+
+---
+
+### Phase 4: Advanced Tiled Inference (Apple Silicon Hardened)
+
+Harden inference/tiling.py for memory-constrained environments.
+
+#### Tasks
+
+- [ ] **4a. 96px overlap default** -- src/corridorkey_mlx/inference/tiling.py
+  - Change DEFAULT_OVERLAP = 64 to DEFAULT_OVERLAP = 96
+  - User-overridable via parameter
+- [ ] **4b. Lazy tile slicing**
+  - Change tiled_inference() signature: accept x as np.ndarray (NHWC float32)
+  - Only convert each tile slice to mx.array right before model(tile)
+  - This keeps the full image out of GPU memory
+  - Update docstring and type hints
+- [ ] **4c. Memory management per tile**
+  - After materializing and accumulating each tile, delete mx references and clear cache
+  - Pattern: materialize -> accumulate to numpy -> del tile refs -> mx.clear_cache()
+- [ ] **4d. Cache limit configuration**
+  - At start of tiled_inference(): mx.set_cache_limit(0) (aggressive: no speculative caching)
+  - Restore original limit at end
+- [ ] **4e. Tiling ignores backbone_size**
+  - When tiling is active, each tile runs through the model at tile_size resolution
+  - backbone_size parameter is not applied per-tile (Phase 3 interaction, Option A)
+  - Document this decision
+
+#### Acceptance Criteria
+
+- [ ] Peak memory during tiled 2048 inference is bounded (no monotonic growth across tiles)
+- [ ] mx.get_cache_memory() returns ~0 after each tile
+- [ ] 96px overlap produces better edge blending than 64px (visual check)
+- [ ] Existing tiling tests updated and passing
+
+---
+
+### Phase 5: Engine API & Compilation Integration
+
+Wire optimizations into CorridorKeyMLXEngine.
+
+#### Tasks
+
+- [ ] **5a. New engine parameters** -- src/corridorkey_mlx/engine.py
+  - fp16=True (NEW, default True)
+  - backbone_size=1024 (NEW, None = same as img_size)
+  - tile_size=512 (NEW, None = no tiling)
+  - tile_overlap=96 (NEW, only used when tile_size set)
+- [ ] **5b. Parameter validation**
+  - backbone_size must be None or divisible by patch_stride (4)
+  - backbone_size must be <= img_size
+  - tile_overlap must be < tile_size
+  - tile_size must be divisible by patch_stride (4)
+  - If compile=True and backbone_size != img_size and backbone_size is not None: disable compile with warning (Phase 3 Option A)
+- [ ] **5c. Tiling integration in process_frame()**
+  - If tile_size is set: route to tiled_inference() instead of direct model(x)
+  - Preprocessing still happens once (full image), then tiles are sliced from the preprocessed numpy array
+  - Tiling trigger: tile_size is not None (explicit opt-in)
+- [ ] **5d. Memory limit safety rail**
+  - On init: mx.set_memory_limit(int(0.8 * total_unified_memory)) if detectable
+  - Fallback: skip if API unavailable
+- [ ] **5e. Benchmark matrix** -- scripts/bench_mlx.py
+  - Add configurations: {fp16, fp32} x {backbone_size: None, 1024} x {tiled, non-tiled} at 2048
+  - Target: <6GB active Metal memory for fp16=True, backbone_size=1024, tiled
+  - Include 512/1024 as regression checks
+- [ ] **5f. Update scripts/smoke_2048.py**
+  - Exercise all new engine parameters
+  - Report memory per configuration
+
+#### Acceptance Criteria
+
+- [ ] Engine accepts all new parameters without breaking existing API (defaults match current behavior)
+- [ ] fp16=False, backbone_size=None, tile_size=None produces identical output to current engine
+- [ ] Benchmark matrix runs and produces comparison table
+- [ ] <6GB active memory target achieved (or documented why not)
+
+---
+
+## Risk Analysis & Mitigation
+
+| Risk | Impact | Mitigation |
+|---|---|---|
+| FP16 GroupNorm drift in refiner (10x scale amplification) | Visible matte artifacts | Mixed precision fallback: backbone FP32, decoder/refiner FP16 |
+| Backbone at 1024 degrades matte edges | Quality regression | Visual validation on real frames; keep backbone_size=None as default until validated |
+| mx.compile incompatible with dual-resolution forward | No compilation speedup for Phase 3 | Disable compile when backbone_size differs; split compilation as follow-up |
+| Tiling + backbone_size interaction undefined | Implementation deadlock | Decision: tiling ignores backbone_size (Option A) |
+| MLX memory APIs version-dependent | Silent failures in benchmarks | Wrap in try/except with clear warnings; document minimum MLX version |
+| No PyTorch reference for decoupled architecture | Cannot validate Phase 3 correctness | Use regression tests (valid ranges, no NaN) + visual inspection |
+
+## Dependencies & Prerequisites
+
+- MLX >= 0.31.0 (for mx.get_active_memory(), mx.clear_cache(), mx.set_cache_limit())
+- Existing golden fixtures (reference/fixtures/golden.npz) for Phase 0/1 parity
+- Real sample images for Phase 3 quality validation
+- Apple Silicon hardware for memory benchmarks (M1/M2 16GB target)
+
+## Success Metrics
+
+| Metric | Current (est.) | Target |
+|---|---|---|
+| Peak memory at 2048 (non-tiled) | ~12GB (FP32) | <6GB (FP16 + backbone 1024) |
+| Peak memory at 2048 (tiled) | unbounded growth | bounded to ~2GB per tile |
+| Throughput at 2048 | baseline | 1.5-2x via FP16 + compile |
+| CPU-GPU syncs per frame | ~6+ | 1 (final output only) |
+| Parity vs FP32 MLX | n/a | <1e-3 for FP16, exact for FP32 path |
+
+## Open Questions
+
+1. **Baseline numbers?** Phase 0 must run first -- feasibility of <6GB depends on current actual usage
+2. **FP16 tolerance for refiner?** The 10x scale factor may force mixed precision from day one
+3. **backbone_size quality at 1024?** Trained at 2048 -- pos_embed interpolation to 1024 is a 4x downsample; needs real-frame validation
+4. **Slim forward mode worth it?** Skipping 5 unused outputs saves VRAM but adds conditional logic to __call__
+5. **mx.set_wired_limit()?** macOS 15+ only; could guarantee resident memory for weights but adds platform dependency
+6. **Split compilation for Phase 3?** Option B (separate compiled_backbone + compiled_refiner) is better perf but more complex; defer?
+
+## References
+
+### Internal
+
+- src/corridorkey_mlx/engine.py -- main engine API
+- src/corridorkey_mlx/model/corridorkey.py -- GreenFormer forward pass (9 outputs)
+- src/corridorkey_mlx/model/hiera.py -- backbone with shape-dependent reshapes
+- src/corridorkey_mlx/model/refiner.py -- GroupNorm pytorch_compatible=True, REFINER_SCALE=10.0
+- src/corridorkey_mlx/inference/tiling.py -- current tiling (64px overlap, numpy accumulators)
+- src/corridorkey_mlx/inference/pipeline.py -- load_model(), compile_model()
+- scripts/bench_mlx.py -- benchmark script (no memory tracking)
+- scripts/smoke_2048.py -- smoke test (has memory API exploration)
+- tests/conftest.py -- tolerance constants (PARITY_TOL_TIGHT=1e-4, PARITY_TOL_E2E=1e-3)
+
+### External
+
+- MLX Unified Memory docs: https://ml-explore.github.io/mlx/build/html/usage/unified_memory.html
+- Writing Fast MLX (Awni Hannun): https://gist.github.com/awni/4beb1f7dfefc6f9426f3a7deee74af50
+- MLX Metal module API: https://ml-explore.github.io/mlx/build/html/python/metal.html

--- a/scripts/bench_mlx.py
+++ b/scripts/bench_mlx.py
@@ -24,7 +24,7 @@ from rich.table import Table
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
 
 from corridorkey_mlx.model.corridorkey import GreenFormer
-from corridorkey_mlx.utils.profiling import warmup_and_bench
+from corridorkey_mlx.utils.profiling import memory_snapshot, reset_peak, warmup_and_bench
 
 console = Console()
 
@@ -61,6 +61,8 @@ def bench_resolution(
     mx.eval(x)  # noqa: S307 — materialize input
 
     results: dict[str, object] = {"resolution": img_size, "batch_size": batch_size}
+
+    reset_peak()
 
     # --- Eager ---
     model_eager = GreenFormer(img_size=img_size)
@@ -108,6 +110,11 @@ def bench_resolution(
         results["compiled_warmup_ms"] = "FAIL"
         results["compiled_steady_ms"] = "FAIL"
         results["compiled_min_ms"] = "FAIL"
+
+    # --- Memory snapshot ---
+    mem = memory_snapshot()
+    results["peak_mb"] = round(mem.peak_mb, 1)
+    results["active_mb"] = round(mem.active_mb, 1)
 
     # --- Parity check ---
     try:
@@ -169,6 +176,8 @@ def main() -> None:
     table.add_column("Compiled Warmup", justify="right")
     table.add_column("Compiled Steady", justify="right")
     table.add_column("Speedup", justify="right")
+    table.add_column("Peak MB", justify="right")
+    table.add_column("Active MB", justify="right")
     table.add_column("Parity", justify="right")
 
     for r in all_results:
@@ -185,6 +194,8 @@ def main() -> None:
             str(r.get("compiled_warmup_ms", "")),
             str(r.get("compiled_steady_ms", "")),
             speedup,
+            str(r.get("peak_mb", "")),
+            str(r.get("active_mb", "")),
             str(r.get("parity_max_diff", "")),
         )
 

--- a/scripts/smoke_2048.py
+++ b/scripts/smoke_2048.py
@@ -14,11 +14,11 @@ import sys
 import time
 from pathlib import Path
 
-import mlx.core as mx
 import numpy as np
 from PIL import Image
 
 from corridorkey_mlx import CorridorKeyMLXEngine
+from corridorkey_mlx.utils.profiling import memory_snapshot, reset_peak
 
 DEFAULT_CHECKPOINT = Path("checkpoints/corridorkey_mlx.safetensors")
 DEFAULT_IMG_SIZE = 2048
@@ -85,27 +85,6 @@ def report_diagnostics(result: dict[str, np.ndarray]) -> bool:
         healthy = False
 
     return healthy
-
-
-def get_peak_memory_mb() -> float | None:
-    """Read peak memory in MB, or None if unavailable."""
-    import contextlib
-
-    with contextlib.suppress(AttributeError):
-        return mx.get_peak_memory() / (1024 * 1024)
-    with contextlib.suppress(Exception):
-        return mx.metal.get_peak_memory() / (1024 * 1024)
-    return None
-
-
-def reset_peak_memory() -> None:
-    """Reset peak memory counter if available."""
-    import contextlib
-
-    with contextlib.suppress(AttributeError):
-        mx.reset_peak_memory()
-    with contextlib.suppress(Exception):
-        mx.metal.reset_peak_memory()
 
 
 def main() -> None:
@@ -191,17 +170,16 @@ def main() -> None:
 
     # -- run inference --
     print("Running inference...")
-    reset_peak_memory()
+    reset_peak()
     start = time.perf_counter()
 
     try:
         result = engine.process_frame(rgb, mask)
     except (RuntimeError, MemoryError) as exc:
         elapsed = time.perf_counter() - start
-        peak_mb = get_peak_memory_mb()
+        mem = memory_snapshot()
         print(f"\nFAILED after {elapsed:.1f}s")
-        if peak_mb is not None:
-            print(f"Peak memory: {peak_mb:.0f} MB")
+        print(f"Peak memory: {mem.peak_mb:.0f} MB")
         print(f"Error: {exc}")
         print("\nPossible causes:")
         print("  - Insufficient unified memory for 2048 inference")
@@ -210,12 +188,13 @@ def main() -> None:
         sys.exit(1)
 
     elapsed = time.perf_counter() - start
-    peak_mb = get_peak_memory_mb()
+    mem = memory_snapshot()
 
     # -- report --
     print(f"\nInference completed in {elapsed:.2f}s")
-    if peak_mb is not None:
-        print(f"Peak memory: {peak_mb:.0f} MB")
+    print(f"Peak memory:   {mem.peak_mb:.0f} MB")
+    print(f"Active memory: {mem.active_mb:.0f} MB")
+    print(f"Cache memory:  {mem.cache_mb:.0f} MB")
     source_label = "synthetic" if using_synthetic else f"loaded ({image_path})"
     print(f"Input: {source_label}, model res={args.img_size}x{args.img_size}")
     print("\nOutputs:")

--- a/src/corridorkey_mlx/inference/pipeline.py
+++ b/src/corridorkey_mlx/inference/pipeline.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 import mlx.core as mx
+from mlx.utils import tree_map
 
 from corridorkey_mlx.io.image import (
     load_alpha_hint,
@@ -33,6 +34,7 @@ def load_model(
     img_size: int = DEFAULT_IMG_SIZE,
     compile: bool = False,
     shapeless: bool = False,
+    fp16: bool = False,
 ) -> GreenFormer:
     """Build GreenFormer and load weights from safetensors checkpoint.
 
@@ -44,12 +46,34 @@ def load_model(
             no shape-dependent logic varies across calls. The Hiera backbone
             uses shape-dependent reshapes, so shapeless is NOT recommended
             unless all inputs share the same spatial dimensions.
+        fp16: If True, cast decoder weights to float16 (mixed precision).
+            Backbone + refiner stay FP32 for numerical stability.
     """
     model = GreenFormer(img_size=img_size)
     model.load_checkpoint(checkpoint)
+    if fp16:
+        _cast_model_fp16(model)
     if compile:
         model = compile_model(model, shapeless=shapeless)
     return model
+
+
+def _cast_model_fp16(model: GreenFormer) -> None:
+    """Cast decoder parameters to float16, keep backbone + refiner FP32.
+
+    Mixed precision strategy:
+    - Backbone FP32: avoids cumulative drift across 24 Hiera blocks
+    - Decoders FP16: biggest parameter count, safe after sigmoid clamping
+    - Refiner FP32: REFINER_SCALE=10.0 amplifies FP16 rounding errors
+      beyond acceptable tolerance (2.3e-3 max_abs vs 1e-3 target)
+    """
+    def to_fp16(x: mx.array) -> mx.array:
+        return x.astype(mx.float16)
+
+    for submodule in (model.alpha_decoder, model.fg_decoder):
+        submodule.update(tree_map(to_fp16, submodule.parameters()))
+    # materialize FP16 parameters — mx.eval is MLX array materialization
+    mx.eval(model.parameters())  # noqa: S307
 
 
 def compile_model(model: GreenFormer, shapeless: bool = False) -> GreenFormer:

--- a/src/corridorkey_mlx/utils/profiling.py
+++ b/src/corridorkey_mlx/utils/profiling.py
@@ -1,7 +1,8 @@
 """Profiling utilities for MLX inference benchmarking.
 
-Provides timing helpers that force mx.eval() for accurate measurement,
-since MLX uses lazy evaluation.
+Provides timing helpers that force graph materialization for accurate
+measurement, since MLX uses lazy evaluation. Also provides memory
+snapshot utilities for tracking VRAM usage.
 """
 
 from __future__ import annotations
@@ -10,6 +11,39 @@ import time
 from dataclasses import dataclass
 
 import mlx.core as mx
+
+
+@dataclass
+class MemorySnapshot:
+    """Snapshot of MLX memory state in megabytes."""
+
+    active_mb: float
+    peak_mb: float
+    cache_mb: float
+
+    def __repr__(self) -> str:
+        return (
+            f"Memory(active={self.active_mb:.1f} MB, "
+            f"peak={self.peak_mb:.1f} MB, "
+            f"cache={self.cache_mb:.1f} MB)"
+        )
+
+
+BYTES_PER_MB = 1024 * 1024
+
+
+def memory_snapshot() -> MemorySnapshot:
+    """Capture current MLX memory state."""
+    return MemorySnapshot(
+        active_mb=mx.get_active_memory() / BYTES_PER_MB,
+        peak_mb=mx.get_peak_memory() / BYTES_PER_MB,
+        cache_mb=mx.get_cache_memory() / BYTES_PER_MB,
+    )
+
+
+def reset_peak() -> None:
+    """Reset the peak memory counter."""
+    mx.reset_peak_memory()
 
 
 @dataclass

--- a/tests/test_fp16_parity.py
+++ b/tests/test_fp16_parity.py
@@ -1,0 +1,122 @@
+"""FP16 vs FP32 parity tests.
+
+Compares FP16 MLX output against FP32 MLX output (NOT PyTorch golden).
+Looser tolerance than FP32-vs-PT because of FP16 rounding + refiner 10x scale.
+"""
+
+from __future__ import annotations
+
+import mlx.core as mx
+import numpy as np
+import pytest
+
+from corridorkey_mlx.inference.pipeline import load_model
+from corridorkey_mlx.utils.layout import nchw_to_nhwc_np
+
+from .conftest import GOLDEN_PATH, IMG_SIZE, MLX_CHECKPOINT_PATH
+
+FP16_TOLERANCE = 1e-3
+
+ENGINE_OUTPUT_KEYS = ["alpha_coarse", "fg_coarse", "alpha_final", "fg_final"]
+
+
+def _skip_if_missing() -> None:
+    if not GOLDEN_PATH.exists():
+        pytest.skip("golden.npz not found")
+    if not MLX_CHECKPOINT_PATH.exists():
+        pytest.skip("MLX checkpoint not found")
+
+
+@pytest.fixture(scope="module")
+def fp32_and_fp16_outputs() -> tuple[dict[str, np.ndarray], dict[str, np.ndarray]]:
+    """Run forward pass with FP32 and FP16 models, return numpy outputs."""
+    _skip_if_missing()
+
+    fixtures = dict(np.load(GOLDEN_PATH))
+    input_nhwc = mx.array(nchw_to_nhwc_np(fixtures["input"]))
+
+    # FP32 baseline
+    model_fp32 = load_model(MLX_CHECKPOINT_PATH, img_size=IMG_SIZE)
+    out_fp32 = model_fp32(input_nhwc)
+    # mx.eval materializes lazy MLX arrays (not Python eval)
+    mx.eval(out_fp32)  # noqa: S307
+    np_fp32 = {k: np.array(v) for k, v in out_fp32.items()}
+
+    # FP16 (mixed precision: backbone FP32, decoder+refiner FP16)
+    # Input stays FP32 — backbone needs full precision
+    model_fp16 = load_model(MLX_CHECKPOINT_PATH, img_size=IMG_SIZE, fp16=True)
+    out_fp16 = model_fp16(input_nhwc)
+    mx.eval(out_fp16)  # noqa: S307
+    np_fp16 = {k: np.array(v) for k, v in out_fp16.items()}
+
+    return np_fp32, np_fp16
+
+
+@pytest.mark.parametrize("key", ENGINE_OUTPUT_KEYS)
+def test_fp16_vs_fp32_parity(
+    key: str,
+    fp32_and_fp16_outputs: tuple[dict[str, np.ndarray], dict[str, np.ndarray]],
+) -> None:
+    """FP16 output matches FP32 output within tolerance for engine-relevant keys."""
+    np_fp32, np_fp16 = fp32_and_fp16_outputs
+
+    assert key in np_fp32, f"Missing FP32 key: {key}"
+    assert key in np_fp16, f"Missing FP16 key: {key}"
+
+    fp32_val = np_fp32[key].astype(np.float32)
+    fp16_val = np_fp16[key].astype(np.float32)
+
+    assert fp32_val.shape == fp16_val.shape, (
+        f"{key} shape mismatch: {fp32_val.shape} vs {fp16_val.shape}"
+    )
+
+    max_abs = float(np.max(np.abs(fp32_val - fp16_val)))
+    mean_abs = float(np.mean(np.abs(fp32_val - fp16_val)))
+
+    assert max_abs < FP16_TOLERANCE, (
+        f"{key}: max_abs={max_abs:.2e} > tol={FP16_TOLERANCE:.1e} (mean={mean_abs:.2e})"
+    )
+
+
+def test_fp16_outputs_valid(
+    fp32_and_fp16_outputs: tuple[dict[str, np.ndarray], dict[str, np.ndarray]],
+) -> None:
+    """FP16 outputs have no NaN/Inf and alpha/fg are in [0, 1]."""
+    _, np_fp16 = fp32_and_fp16_outputs
+
+    for key in ENGINE_OUTPUT_KEYS:
+        val = np_fp16[key].astype(np.float32)
+        assert not np.any(np.isnan(val)), f"{key} has NaN"
+        assert not np.any(np.isinf(val)), f"{key} has Inf"
+        assert float(np.min(val)) >= 0.0, f"{key} min={np.min(val):.4f} < 0"
+        assert float(np.max(val)) <= 1.0, f"{key} max={np.max(val):.4f} > 1"
+
+
+def test_fp32_path_unaffected() -> None:
+    """load_model without fp16 returns FP32 parameters (opt-in check)."""
+    if not MLX_CHECKPOINT_PATH.exists():
+        pytest.skip("MLX checkpoint not found")
+
+    model = load_model(MLX_CHECKPOINT_PATH, img_size=IMG_SIZE, fp16=False)
+    params = model.parameters()
+    first_param = next(iter(_flatten_params(params)))
+    assert first_param.dtype == mx.float32, (
+        f"Expected float32 params when fp16=False, got {first_param.dtype}"
+    )
+
+
+def _flatten_params(params: dict | list | mx.array) -> list[mx.array]:
+    """Recursively flatten nested parameter dict/list to list of arrays."""
+    if isinstance(params, mx.array):
+        return [params]
+    if isinstance(params, dict):
+        result = []
+        for v in params.values():
+            result.extend(_flatten_params(v))
+        return result
+    if isinstance(params, list):
+        result = []
+        for v in params:
+            result.extend(_flatten_params(v))
+        return result
+    return []


### PR DESCRIPTION
## Summary

- **FP16 mixed precision**: decoders cast to FP16 (backbone+refiner stay FP32 for accuracy)
- **Eliminate CPU-GPU roundtrips**: MLX-native preprocessing, slim forward mode (4 outputs vs 9)
- **Decoupled backbone resolution**: backbone at 1024 while refiner runs at full 2048 — 6.3x faster, 3.4x less peak memory
- **Hardened tiled inference**: 96px overlap, lazy tile slicing, per-tile cache clearing, bounded memory growth
- **Engine API**: new params `fp16`, `backbone_size`, `tile_size`, `tile_overlap` with validation
- **Bug fix**: mask resize now handles mismatched image/mask dimensions

## Benchmark Highlights (M3 Max, 2048x2048)

| Config | Median | Peak MB |
|--------|-------:|--------:|
| Baseline (FP32, full backbone) | 9,068 ms | 27,560 |
| Backbone 1024 | 1,447 ms | 8,044 |
| Tiled 512 | 3,467 ms | 2,626 |
| All optimizations (FP16+bb1024+tiled) | 8,450 ms* | 2,301 |

*wall time with real images + resize overhead

## Test plan

- [x] 115 tests pass, 0 failures
- [x] Resolution benchmark (256/512/1024)
- [x] Engine config matrix (fp16/fp32 × backbone × tiled at 2048)
- [x] 2048 smoke test with all optimizations — PASSED
- [x] Full results in `docs/benchmarks/RESULTS.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)